### PR TITLE
Implement retrieval of help from REST API

### DIFF
--- a/MolTwister.cpp
+++ b/MolTwister.cpp
@@ -62,6 +62,215 @@ void CMolTwister::run(C3DView* view3D, const std::string& hostIP, const std::str
     }
 }
 
+std::string CMolTwister::genTerminalStartupInfo() const
+{
+    std::string introText = CBashColor::clearScreen(false);
+
+    introText+= CBashColor::setSpecial(CBashColor::specBright, false);
+    introText+= "----------------------------------------------------------------\r\n";
+    introText+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+    introText+= CBashColor::setColor(CBashColor::colYellow, CBashColor::colNone, false);
+    introText+= CASCIIUtility::sprintf("                        MolTwister V%s                       \r\n", MOLTWISTER_VER);
+    introText+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+    introText+= CBashColor::setSpecial(CBashColor::specBright, false);
+    introText+= "----------------------------------------------------------------\r\n";
+    introText+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+    introText+= CBashColor::setColor(CBashColor::colYellow, CBashColor::colNone, false);
+    introText+= " Copyright (C) 2023 Richard Olsen.\r\n";
+    introText+= "\r\n";
+    introText+= " This program is free software: you can redistribute it and/or\r\n";
+    introText+= " modify it under the terms of the GNU General Public License as\r\n";
+    introText+= " published by the Free Software Foundation, either version 3 of\r\n";
+    introText+= " the License, or (at your option) any later version.\r\n";
+    introText+= "\r\n";
+    introText+= " This program is distributed in the hope that it will be useful,\r\n";
+    introText+= " but WITHOUT ANY WARRANTY; without even the implied warranty of\r\n";
+    introText+= " MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\r\n";
+    introText+= " GNU General Public License for more details.\r\n";
+    introText+= "\r\n";
+    introText+= " You should have received a copy of the GNU General Public\r\n";
+    introText+= " License along with this program. If not, see\r\n";
+    introText+= "               <https://www.gnu.org/licenses/>.\r\n";
+    introText+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+    introText+= "\r\n";
+    introText+= " Write 'help' to list available commands, write 'help <command>'\r\n";
+    introText+= " to obtain help for a specific command, and type 'exit' to exit\r\n";
+    introText+= " the program. \r\n";
+    introText+= "\r\n";
+    introText+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+
+    return introText;
+}
+
+std::string CMolTwister::genHelp() const
+{
+    std::string helpText = "\r\n";
+
+    for(int i=0; i<(int)cmdList_.size(); i++)
+    {
+        helpText+= CBashColor::setColor(CBashColor::colGreen, CBashColor::colNone, false);
+        helpText+= CBashColor::setSpecial(CBashColor::specBright, false);
+        helpText+= CASCIIUtility::sprintf("\t%-15s", cmdList_[i]->getCmd().data());
+        helpText+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+        helpText+= CASCIIUtility::sprintf(" - %s\r\n", cmdList_[i]->getTopLevHelpString().data());
+    }
+
+    helpText+= CASCIIUtility::sprintf("\r\n");
+    for(int i=0; i<(int)tutorialPool_.getCount(); i++)
+    {
+        const std::string tutorialString = std::string("tutorial") + std::to_string(i+1);
+        const std::string tutorialDescription = tutorialPool_.getDocumentHeader(i);
+
+        helpText+= CBashColor::setColor(CBashColor::colMagenta, CBashColor::colNone, false);
+        helpText+= CBashColor::setSpecial(CBashColor::specBright, false);
+        helpText+= CASCIIUtility::sprintf("\t%-15s", tutorialString.data());
+        helpText+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+        helpText+= CASCIIUtility::sprintf(" - %s\r\n", tutorialDescription.data());
+    }
+
+    helpText+= CASCIIUtility::sprintf("\r\n\tAny commands not recognized by MolTwister will be\r\n");
+    helpText+= CASCIIUtility::sprintf("\tredirected to the shell (e.g. ssh, vim, pico). Write\r\n");
+    helpText+= CASCIIUtility::sprintf("\t'help __MarkDown__' to create a Markdown help document.\r\n");
+
+    helpText+= CASCIIUtility::sprintf("\r\n\tIn the 3D View you can use the mouse to:\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Rotate the system by holding down the left mouse\r\n");
+    helpText+= CASCIIUtility::sprintf("\t     button inside the view while moving the mouse\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Zoom in and out by holding down the middle mouse\r\n");
+    helpText+= CASCIIUtility::sprintf("\t     button (or mouse wheel) inside the view while moving\r\n");
+    helpText+= CASCIIUtility::sprintf("\t     the mouse\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Pan the system by holding down the right mouse button\r\n");
+    helpText+= CASCIIUtility::sprintf("\t     inside the view while moving the mouse\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Select or deselect atoms by holding down shift, while\r\n");
+    helpText+= CASCIIUtility::sprintf("\t     clicking the left mouse button\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Deselect all atoms by holding down shift, while clicking\r\n");
+    helpText+= CASCIIUtility::sprintf("\t     the right mouse button\r\n");
+    helpText+= CASCIIUtility::sprintf("\r\n");
+    helpText+= CASCIIUtility::sprintf("\tHotkeys when 3D view is the active window:\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Alt + f: Fullscreen (use Esc to exit fullscreen mode)\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Alt + o: Switch between orthographic and perspective mode\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Alt + a: Switch on or off axis\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Alt + i: Switch on or off Coulomb energy iso-surfaces.\r\n");
+    helpText+= CASCIIUtility::sprintf("\t              Should only be used on smaller systems, with a\r\n");
+    helpText+= CASCIIUtility::sprintf("\t              few molecules, due to the slow nature of the\r\n");
+    helpText+= CASCIIUtility::sprintf("\t              applied algorithms.\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Alt + p: Switch on or off visibility of bonds stretching\r\n");
+    helpText+= CASCIIUtility::sprintf("\t              across periodic boundaries (PBC)\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * ->:      Go forward one frame or 10, 100, 1000, with Shift,\r\n");
+    helpText+= CASCIIUtility::sprintf("\t              Alt, Shift+Alt, respectively\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * <-:      Go back one frame or 10, 100, 1000, with Shift,\r\n");
+    helpText+= CASCIIUtility::sprintf("\t              Alt, Shift+Alt, respectively\r\n");
+    helpText+= CASCIIUtility::sprintf("\r\n");
+    helpText+= CASCIIUtility::sprintf("\tNotes on units and conventions:\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * The Angstrom unit is denoted as AA\r\n");
+    helpText+= CASCIIUtility::sprintf("\r\n");
+    helpText+= CASCIIUtility::sprintf("\tTutorials:\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * To view a tutorial, execute the appropirate 'tutorial#' command\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * The tutorial is written in Markdown, which is human readable text\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * You can store the Markdown text to file by 'tutorial# > filename.md'\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * Use a Markdown compiler to convert to HTML or PDF.\r\n");
+    helpText+= CASCIIUtility::sprintf("\t     E.g., Visual Studio Code and a Markdown plugin\r\n");
+    helpText+= CASCIIUtility::sprintf("\t   * The tutorials are also included in the Markdown file created by\r\n");
+    helpText+= CASCIIUtility::sprintf("\t     the 'help __MarkDown__' command\r\n");
+
+    return helpText;
+}
+
+std::string CMolTwister::genHelpForCommand(const std::string& cmdString, const std::string& commandLine) const
+{
+    std::string helpOnCommand;
+
+    int cmdIndex = -1;
+
+    for(int i=0; i<(int)cmdList_.size(); i++)
+    {
+        if(cmdList_[i]->checkCmd(cmdString.data()))
+        {
+            cmdIndex = i;
+            break;
+        }
+    }
+
+    if(cmdIndex >= 0)
+    {
+        std::string subCmdString = CASCIIUtility::getWord(commandLine, 2);
+        CASCIIUtility::removeWhiteSpace(subCmdString, " \t\r\n");
+
+        helpOnCommand+= CBashColor::setColor(CBashColor::colGreen, CBashColor::colNone, false);
+        helpOnCommand+= CBashColor::setSpecial(CBashColor::specBright, false);
+        helpOnCommand+= CASCIIUtility::sprintf("\r\n\t%s", cmdList_[cmdIndex]->getCmd().data());
+        helpOnCommand+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+        if(!subCmdString.empty())
+        {
+            helpOnCommand+= CBashColor::setColor(CBashColor::colCyan, CBashColor::colNone, false);
+            helpOnCommand+= CASCIIUtility::sprintf(" %s", subCmdString.data());
+            helpOnCommand+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+        }
+        helpOnCommand+= CASCIIUtility::sprintf(" - %s\r\n", cmdList_[cmdIndex]->getTopLevHelpString().data());
+
+        helpOnCommand+= CBashColor::setSpecial(CBashColor::specBright, false);
+        helpOnCommand+= CASCIIUtility::sprintf("\t---------------------------------------------------------------------------\r\n\r\n");
+        helpOnCommand+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+
+        if(subCmdString.empty())
+            helpOnCommand+= CASCIIUtility::sprintf("%s\r\n", cmdList_[cmdIndex]->getHelpString().data());
+        else
+            helpOnCommand+= CASCIIUtility::sprintf("%s\r\n", cmdList_[cmdIndex]->getHelpString(subCmdString).data());
+
+
+        helpOnCommand+= CBashColor::setSpecial(CBashColor::specBright, false);
+        helpOnCommand+= CASCIIUtility::sprintf("\t---------------------------------------------------------------------------\r\n");
+        helpOnCommand+= CBashColor::setColor(CBashColor::colNone, CBashColor::colNone, false);
+    }
+    else
+    {
+        helpOnCommand+= CASCIIUtility::sprintf("\r\n\tCould not find help for %s!\r\n", cmdString.data());
+    }
+
+    return helpOnCommand;
+}
+
+std::string CMolTwister::genMarkdownHelpDoc() const
+{
+    std::string markdownDoc;
+
+    // List commands
+    markdownDoc+= CASCIIUtility::sprintf("# List of commands\r\n\r\n");
+    for(int i=0; i<(int)cmdList_.size(); i++)
+    {
+        std::string markdownText;
+
+        markdownDoc+= CASCIIUtility::sprintf("## %s\r\n\r\n", cmdList_[i]->getCmd().data());
+        markdownText = cmdList_[i]->getTopLevHelpString();
+        markdownText = CASCIIUtility::trimFromLeft(markdownText, "\t", 1);
+        markdownDoc+= CASCIIUtility::sprintf("*%s*\r\n\r\n", markdownText.data());
+
+        markdownText = cmdList_[i]->getHelpString();
+        markdownText = CASCIIUtility::createMarkDownCodeBlock(markdownText, 4, true);
+        markdownDoc+= CASCIIUtility::sprintf("%s\r\n", markdownText.data());
+
+        std::shared_ptr<std::vector<std::string>> subCmdList = cmdList_[i]->getListOfSubCommands();
+        if(subCmdList)
+        {
+            for(int j=0; j<(int)subCmdList->size(); j++)
+            {
+                markdownDoc+= CASCIIUtility::sprintf("### %s\r\n\r\n", (*subCmdList)[j].data());
+
+                markdownText = cmdList_[i]->getHelpString((*subCmdList)[j]);
+                markdownText = CASCIIUtility::createMarkDownCodeBlock(markdownText, 4, true);
+                markdownDoc+= CASCIIUtility::sprintf("%s\r\n", markdownText.data());
+            }
+        }
+    }
+
+    // List tutorials
+    for(int i=0; i<tutorialPool_.getCount(); i++)
+    {
+        markdownDoc+= CASCIIUtility::sprintf("\r\n%s\r\n", tutorialPool_.getDocument(i).data());
+    }
+
+    return markdownDoc;
+}
+
 void* CMolTwister::threadRun(void* arg)
 {
     CMolTwister* mtPtr = (CMolTwister*)arg;
@@ -187,41 +396,8 @@ bool CMolTwister::_run()
     std::string command;
     std::string commandLine;
     bool quit = false;
-    
-    CBashColor::clearScreen();
-    
-    CBashColor::setSpecial(CBashColor::specBright);
-    printf("----------------------------------------------------------------\r\n");
-    CBashColor::setColor();
-    CBashColor::setColor(CBashColor::colYellow);
-    printf("                        MolTwister V%s                       \r\n", MOLTWISTER_VER);
-    CBashColor::setColor();
-    CBashColor::setSpecial(CBashColor::specBright);
-    printf("----------------------------------------------------------------\r\n");
-    CBashColor::setColor();
-    CBashColor::setColor(CBashColor::colYellow);
-    printf(" Copyright (C) 2023 Richard Olsen.\r\n");
-    printf("\r\n");
-    printf(" This program is free software: you can redistribute it and/or\r\n");
-    printf(" modify it under the terms of the GNU General Public License as\r\n");
-    printf(" published by the Free Software Foundation, either version 3 of\r\n");
-    printf(" the License, or (at your option) any later version.\r\n");
-    printf("\r\n");
-    printf(" This program is distributed in the hope that it will be useful,\r\n");
-    printf(" but WITHOUT ANY WARRANTY; without even the implied warranty of\r\n");
-    printf(" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\r\n");
-    printf(" GNU General Public License for more details.\r\n");
-    printf("\r\n");
-    printf(" You should have received a copy of the GNU General Public\r\n");
-    printf(" License along with this program. If not, see\r\n");
-    printf("               <https://www.gnu.org/licenses/>.\r\n");
-    CBashColor::setColor();
-    printf("\r\n");
-    printf(" Write 'help' to list available commands, write 'help <command>'\r\n");
-    printf(" to obtain help for a specific command, and type 'exit' to exit\r\n");
-    printf(" the program. \r\n");
-    printf("\r\n");
-    CBashColor::setColor();
+
+    printf("%s", genTerminalStartupInfo().c_str());
 
     cmdList_.clear();
     CMolTwisterCommandPool::generateCmdList(&state_, cmdList_);
@@ -258,72 +434,7 @@ bool CMolTwister::_run()
             
             if(cmdString.size() == 0)
             {
-                printf("\r\n");
-                for(int i=0; i<(int)cmdList_.size(); i++)
-                {
-                    CBashColor::setColor(CBashColor::colGreen);
-                    CBashColor::setSpecial(CBashColor::specBright);
-                    printf("\t%-15s", cmdList_[i]->getCmd().data());
-                    CBashColor::setColor();
-                    printf(" - %s\r\n", cmdList_[i]->getTopLevHelpString().data());
-                }
-
-                printf("\r\n");
-                for(int i=0; i<(int)tutorialPool_.getCount(); i++)
-                {
-                    const std::string tutorialString = std::string("tutorial") + std::to_string(i+1);
-                    const std::string tutorialDescription = tutorialPool_.getDocumentHeader(i);
-
-                    CBashColor::setColor(CBashColor::colMagenta);
-                    CBashColor::setSpecial(CBashColor::specBright);
-                    printf("\t%-15s", tutorialString.data());
-                    CBashColor::setColor();
-                    printf(" - %s\r\n", tutorialDescription.data());
-                }
-
-                printf("\r\n\tAny commands not recognized by MolTwister will be\r\n");
-                printf("\tredirected to the shell (e.g. ssh, vim, pico). Write\r\n");
-                printf("\t'help __MarkDown__' to create a Markdown help document.\r\n");
-
-                printf("\r\n\tIn the 3D View you can use the mouse to:\r\n");
-                printf("\t   * Rotate the system by holding down the left mouse\r\n");
-                printf("\t     button inside the view while moving the mouse\r\n");
-                printf("\t   * Zoom in and out by holding down the middle mouse\r\n");
-                printf("\t     button (or mouse wheel) inside the view while moving\r\n");
-                printf("\t     the mouse\r\n");
-                printf("\t   * Pan the system by holding down the right mouse button\r\n");
-                printf("\t     inside the view while moving the mouse\r\n");                
-                printf("\t   * Select or deselect atoms by holding down shift, while\r\n");
-                printf("\t     clicking the left mouse button\r\n");
-                printf("\t   * Deselect all atoms by holding down shift, while clicking\r\n");
-                printf("\t     the right mouse button\r\n");
-                printf("\r\n");
-                printf("\tHotkeys when 3D view is the active window:\r\n");
-                printf("\t   * Alt + f: Fullscreen (use Esc to exit fullscreen mode)\r\n");
-                printf("\t   * Alt + o: Switch between orthographic and perspective mode\r\n");
-                printf("\t   * Alt + a: Switch on or off axis\r\n");
-                printf("\t   * Alt + i: Switch on or off Coulomb energy iso-surfaces.\r\n");
-                printf("\t              Should only be used on smaller systems, with a\r\n");
-                printf("\t              few molecules, due to the slow nature of the\r\n");
-                printf("\t              applied algorithms.\r\n");
-                printf("\t   * Alt + p: Switch on or off visibility of bonds stretching\r\n");
-                printf("\t              across periodic boundaries (PBC)\r\n");
-                printf("\t   * ->:      Go forward one frame or 10, 100, 1000, with Shift,\r\n");
-                printf("\t              Alt, Shift+Alt, respectively\r\n");
-                printf("\t   * <-:      Go back one frame or 10, 100, 1000, with Shift,\r\n");
-                printf("\t              Alt, Shift+Alt, respectively\r\n");
-                printf("\r\n");
-                printf("\tNotes on units and conventions:\r\n");
-                printf("\t   * The Angstrom unit is denoted as AA\r\n");
-                printf("\r\n");
-                printf("\tTutorials:\r\n");
-                printf("\t   * To view a tutorial, execute the appropirate 'tutorial#' command\r\n");
-                printf("\t   * The tutorial is written in Markdown, which is human readable text\r\n");
-                printf("\t   * You can store the Markdown text to file by 'tutorial# > filename.md'\r\n");
-                printf("\t   * Use a Markdown compiler to convert to HTML or PDF.\r\n");
-                printf("\t     E.g., Visual Studio Code and a Markdown plugin\r\n");
-                printf("\t   * The tutorials are also included in the Markdown file created by\r\n");
-                printf("\t     the 'help __MarkDown__' command\r\n");
+                printf("%s", genHelp().c_str());
             }
             else if(cmdString == "__MarkDown__")
             {
@@ -332,42 +443,8 @@ bool CMolTwister::_run()
 
                 if(mkdFile)
                 {
-                    // List commands
-                    fprintf(mkdFile, "# List of commands\r\n\r\n");
-                    for(int i=0; i<(int)cmdList_.size(); i++)
-                    {
-                        std::string markdownText;
+                    fprintf(mkdFile, "%s", genMarkdownHelpDoc().c_str());
 
-                        fprintf(mkdFile, "## %s\r\n\r\n", cmdList_[i]->getCmd().data());
-                        markdownText = cmdList_[i]->getTopLevHelpString();
-                        markdownText = CASCIIUtility::trimFromLeft(markdownText, "\t", 1);
-                        fprintf(mkdFile, "*%s*\r\n\r\n", markdownText.data());
-
-                        markdownText = cmdList_[i]->getHelpString();
-                        markdownText = CASCIIUtility::createMarkDownCodeBlock(markdownText, 4, true);
-                        fprintf(mkdFile, "%s\r\n", markdownText.data());
-
-                        std::shared_ptr<std::vector<std::string>> subCmdList = cmdList_[i]->getListOfSubCommands();
-                        if(subCmdList)
-                        {
-                            for(int j=0; j<(int)subCmdList->size(); j++)
-                            {
-                                fprintf(mkdFile, "### %s\r\n\r\n", (*subCmdList)[j].data());
-
-                                markdownText = cmdList_[i]->getHelpString((*subCmdList)[j]);
-                                markdownText = CASCIIUtility::createMarkDownCodeBlock(markdownText, 4, true);
-                                fprintf(mkdFile, "%s\r\n", markdownText.data());
-                            }
-                        }
-                    }
-
-                    // List tutorials
-                    for(int i=0; i<tutorialPool_.getCount(); i++)
-                    {
-                        fprintf(mkdFile, "\r\n%s\r\n", tutorialPool_.getDocument(i).data());
-                    }
-
-                    // Clean up
                     fclose(mkdFile);
                     printf("\r\n\tCreated file %s!\r\n", mkdFileName.data());
                 }
@@ -378,52 +455,7 @@ bool CMolTwister::_run()
             }
             else
             {
-                int cmdIndex = -1;
-                
-                for(int i=0; i<(int)cmdList_.size(); i++)
-                {
-                    if(cmdList_[i]->checkCmd(cmdString.data()))
-                    {
-                        cmdIndex = i;
-                        break;
-                    }
-                }
-                
-                if(cmdIndex >= 0)
-                {
-                    std::string subCmdString = CASCIIUtility::getWord(commandLine, 2);
-                    CASCIIUtility::removeWhiteSpace(subCmdString, " \t\r\n");
-
-                    CBashColor::setColor(CBashColor::colGreen);
-                    CBashColor::setSpecial(CBashColor::specBright);
-                    printf("\r\n\t%s", cmdList_[cmdIndex]->getCmd().data());
-                    CBashColor::setColor();
-                    if(!subCmdString.empty())
-                    {
-                        CBashColor::setColor(CBashColor::colCyan);
-                        printf(" %s", subCmdString.data());
-                        CBashColor::setColor();
-                    }
-                    printf(" - %s\r\n", cmdList_[cmdIndex]->getTopLevHelpString().data());
-                    
-                    CBashColor::setSpecial(CBashColor::specBright);
-                    printf("\t---------------------------------------------------------------------------\r\n\r\n");
-                    CBashColor::setColor();
-
-                    if(subCmdString.empty())
-                        printf("%s\r\n", cmdList_[cmdIndex]->getHelpString().data());
-                    else
-                        printf("%s\r\n", cmdList_[cmdIndex]->getHelpString(subCmdString).data());
-
-
-                    CBashColor::setSpecial(CBashColor::specBright);
-                    printf("\t---------------------------------------------------------------------------\r\n");
-                    CBashColor::setColor();
-                }
-                else
-                {
-                    printf("\r\n\tCould not find help for %s!\r\n", cmdString.data());
-                }
+                printf("%s", genHelpForCommand(cmdString, commandLine).c_str());
             }
         }
         

--- a/MolTwister.h
+++ b/MolTwister.h
@@ -35,6 +35,12 @@ public:
     
 public:
     void run(C3DView* view3D, const std::string& hostIP, const std::string& hostPort);
+    std::string genTerminalStartupInfo() const;
+    std::string genHelp() const;
+    std::string genHelpForCommand(const std::string& cmdString, const std::string& commandLine) const;
+    std::string genMarkdownHelpDoc() const;
+    int getTutorialDocCount() const { return (int)tutorialPool_.getCount(); }
+    std::string getTutorialDoc(const int& index) { return tutorialPool_.getDocument(index); }
     std::vector<std::shared_ptr<CAtom>>* getAtomsPtr() { return &state_.atoms_; }
     std::vector<std::shared_ptr<CGLObject>>* getGLObjsPtr() { return &state_.glObjects_; }
     int* getCurrFramePtr() { return &state_.currentFrame_; }

--- a/MolTwisterPythonExtensions.h
+++ b/MolTwisterPythonExtensions.h
@@ -598,6 +598,97 @@ static PyObject* moltwister_mt_get_host_port(PyObject*, PyObject* args)
     return ret;
 }
 
+static PyObject* moltwister_mt_get_startup_info(PyObject*, PyObject* args)
+{
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if(!PyArg_ParseTuple(args, ":get_startup_info"))
+    {
+        PyGILState_Release(gilState);
+        return nullptr;
+    }
+
+    PyObject* ret = Py_BuildValue("s", g_pMT->genTerminalStartupInfo().data());
+    PyGILState_Release(gilState);
+    return ret;
+}
+
+static PyObject* moltwister_mt_get_help(PyObject*, PyObject* args)
+{
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if(!PyArg_ParseTuple(args, ":get_help"))
+    {
+        PyGILState_Release(gilState);
+        return nullptr;
+    }
+
+    PyObject* ret = Py_BuildValue("s", g_pMT->genHelp().data());
+    PyGILState_Release(gilState);
+    return ret;
+}
+
+static PyObject* moltwister_mt_get_help_for_command(PyObject*, PyObject* args)
+{
+    const char* cmdString;
+    const char* commandLine;
+
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if(!PyArg_ParseTuple(args, "ss", &cmdString, &commandLine))
+    {
+        PyGILState_Release(gilState);
+        return nullptr;
+    }
+
+    PyObject* ret = Py_BuildValue("s", g_pMT->genHelpForCommand(cmdString, commandLine).data());
+    Py_INCREF(Py_None);
+    PyGILState_Release(gilState);
+    return ret;
+}
+
+static PyObject* moltwister_mt_get_help_as_markdown(PyObject*, PyObject* args)
+{
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if(!PyArg_ParseTuple(args, ":get_help_as_markdown"))
+    {
+        PyGILState_Release(gilState);
+        return nullptr;
+    }
+
+    PyObject* ret = Py_BuildValue("s", g_pMT->genMarkdownHelpDoc().data());
+    PyGILState_Release(gilState);
+    return ret;
+}
+
+static PyObject* moltwister_mt_get_tutorial_count(PyObject*, PyObject* args)
+{
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if(!PyArg_ParseTuple(args, ":get_tutorial_count"))
+    {
+        PyGILState_Release(gilState);
+        return nullptr;
+    }
+
+    PyObject* ret = Py_BuildValue("i", g_pMT->getTutorialDocCount());
+    PyGILState_Release(gilState);
+    return ret;
+}
+
+static PyObject* moltwister_mt_get_tutorial(PyObject*, PyObject* args)
+{
+    int tutorialIndex;
+
+    PyGILState_STATE gilState = PyGILState_Ensure();
+    if(!PyArg_ParseTuple(args, "i", &tutorialIndex))
+    {
+        PyGILState_Release(gilState);
+        return nullptr;
+    }
+
+    PyObject* ret = Py_BuildValue("s", g_pMT->getTutorialDoc(tutorialIndex).data());
+    Py_INCREF(Py_None);
+    PyGILState_Release(gilState);
+    return ret;
+}
+
 static PyMethodDef MolTwisterMethods[] =
 {
     // The mt_.. style commands are there for backward compatibility
@@ -637,6 +728,12 @@ static PyMethodDef MolTwisterMethods[] =
     {"end_progress", moltwister_mt_end_progress, METH_VARARGS, "Finishes progress bar, showing as 100 percent complete."},
     {"get_host_ip", moltwister_mt_get_host_ip, METH_VARARGS, "Returns the currently set host IP used for the MolTwister REST API, if this is enabled."},
     {"get_host_port", moltwister_mt_get_host_port, METH_VARARGS, "Returns the currently set host port used for the MolTwister REST API, if this is enabled."},
+    {"get_startup_info", moltwister_mt_get_startup_info, METH_VARARGS, "Returns startup info of MolTwister, such as lincensing and version."},
+    {"get_help", moltwister_mt_get_help, METH_VARARGS, "Returns top-level help for MolTwister."},
+    {"get_help_for_command", moltwister_mt_get_help_for_command, METH_VARARGS, "Returns command-level help for MolTwister."},
+    {"get_help_as_markdown", moltwister_mt_get_help_as_markdown, METH_VARARGS, "Returns help as a Markdown formatted string."},
+    {"get_tutorial_count", moltwister_mt_get_tutorial_count, METH_VARARGS, "Returns the number of available tutorials."},
+    {"get_tutorial", moltwister_mt_get_tutorial, METH_VARARGS, "Returns the tutorial with the given index."},
 
     {nullptr, nullptr, 0, nullptr}
 };

--- a/RestAPI/MolTwisterRestAPI.cpp
+++ b/RestAPI/MolTwisterRestAPI.cpp
@@ -1,3 +1,23 @@
+//
+// Copyright (C) 2024 Richard Olsen.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This file is part of MolTwister.
+//
+// MolTwister is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// MolTwister is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with MolTwister.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #include <pthread.h>
 #include <stdio.h>
 #include <string>

--- a/RestAPI/MolTwisterRestAPI.h
+++ b/RestAPI/MolTwisterRestAPI.h
@@ -1,3 +1,23 @@
+//
+// Copyright (C) 2024 Richard Olsen.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This file is part of MolTwister.
+//
+// MolTwister is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// MolTwister is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with MolTwister.  If not, see <https://www.gnu.org/licenses/>.
+//
+
 #pragma once
 #include <string>
 #include <vector>

--- a/RestAPI/Python/MolTwisterAPI.py
+++ b/RestAPI/Python/MolTwisterAPI.py
@@ -1,6 +1,33 @@
+#
+# Copyright (C) 2024 Richard Olsen.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This file is part of MolTwister.
+#
+# MolTwister is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# MolTwister is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MolTwister.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 from flask import Flask, request
 from waitress import serve
 import moltwister as mt
+
+markdownHelpDoc = mt.get_help_as_markdown().replace('\r', '').split('\n')
+tutorialCount = mt.get_tutorial_count()
+tutorials = []
+
+for i in range(0, tutorialCount):
+    tutorials.append(mt.get_tutorial(i).replace('\r', '').split('\n'))
 
 app = Flask(__name__)
 
@@ -8,11 +35,48 @@ app = Flask(__name__)
 def return_api_name():
     return {"api_name" : "MolTwister"}
 
+@app.get('/startup_info')
+def return_startup_info():
+    return {"startup_info" : mt.get_startup_info()}
+
+@app.get('/help')
+def return_help():
+    return {"help" : mt.get_help()}
+
+@app.get('/help_cmd')
+def return_help_cmd():
+    jsonPayload = request.get_json(force=True)
+    commandString = jsonPayload['cmd']
+    commandLine = jsonPayload['cmdline']
+    return {"help_cmd" : mt.get_help_for_command(commandString, commandLine)}
+
+@app.get('/help_md')
+def return_help_md():
+    jsonPayload = request.get_json(force=True)
+    if jsonPayload['ret'] == 'count':
+        return {"help_md_cnt" : len(markdownHelpDoc)}
+    if jsonPayload['ret'] == 'line':
+        lineIndex = int(jsonPayload['index'])
+        return {'help_md' : markdownHelpDoc[lineIndex]}
+
+@app.get('/tutorial')
+def return_tutorial():
+    jsonPayload = request.get_json(force=True)
+    if jsonPayload['ret'] == 'tutcount':
+        return {"tutcnt" : len(tutorials)}
+    if jsonPayload['ret'] == 'linecount':
+        tutIndex = int(jsonPayload['tutindex'])
+        return {"linecnt" : len(tutorials[tutIndex])}
+    if jsonPayload['ret'] == 'line':
+        tutIndex = int(jsonPayload['tutindex'])
+        lineIndex = int(jsonPayload['lineindex'])
+        return {'tutorial' : tutorials[tutIndex][lineIndex]}
+
 @app.route('/exec', methods=['POST'])
 def execute_command():
     jsonPayload = request.get_json(force=True)
     commandString = jsonPayload['cmd']
-    return mt.exec(commandString)
+    return {"exec_ret" : mt.exec(commandString)}
 
 if __name__ == "__main__":
     serve(app, host=mt.get_host_ip(), port=int(mt.get_host_port()))

--- a/Utilities/ASCIIUtility.cpp
+++ b/Utilities/ASCIIUtility.cpp
@@ -20,6 +20,9 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
+#include <cstdio>
+#include <cstdarg>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -424,4 +427,25 @@ std::string CASCIIUtility::addTabsToDocument(const std::string& document)
     }
 
     return newDocument;
+}
+
+std::string CASCIIUtility::sprintf(const char* format, ...)
+{
+    size_t size = 1024;
+    std::vector<char> buffer(size);
+
+    va_list args;
+    va_start(args, format);
+    int needed = std::vsnprintf(buffer.data(), buffer.size(), format, args);
+    va_end(args);
+
+    if(needed >= static_cast<int>(buffer.size()))
+    {
+        buffer.resize(needed + 1);
+        va_start(args, format);
+        std::vsnprintf(buffer.data(), buffer.size(), format, args);
+        va_end(args);
+    }
+
+    return std::string(buffer.data());
 }

--- a/Utilities/ASCIIUtility.h
+++ b/Utilities/ASCIIUtility.h
@@ -45,4 +45,5 @@ public:
     static std::string argsToString(const std::vector<std::string>& arguments, size_t firstArgToInclude);
     static std::string createMarkDownCodeBlock(std::string str, int numSpaces, bool removeFirstTab=false);
     static std::string addTabsToDocument(const std::string& document);
+    static std::string sprintf(const char* format, ...);
 };

--- a/Utilities/BashColor.cpp
+++ b/Utilities/BashColor.cpp
@@ -24,15 +24,15 @@
 #include <string.h>
 #include "BashColor.h"
 
-#define CLI_HIDE_CUR            
-#define CLI_SHOW_CUR            
-#define CLI_SAVE_CUR_POS        
-#define CLI_REST_CUR_POS        
-#define CLI_CLR_LAST_LINE       
-#define CLI_MV_CUR_UP           
-#define CLI_MV_CUR_DN           
+#define CLI_HIDE_CUR
+#define CLI_SHOW_CUR
+#define CLI_SAVE_CUR_POS
+#define CLI_REST_CUR_POS
+#define CLI_CLR_LAST_LINE
+#define CLI_MV_CUR_UP
+#define CLI_MV_CUR_DN
 
-void CBashColor::setColor(EColor foreground, EColor background)
+std::string CBashColor::setColor(EColor foreground, EColor background, bool printToStdOut)
 {
 #ifndef DEBUG
     char num[3];
@@ -55,11 +55,14 @@ void CBashColor::setColor(EColor foreground, EColor background)
     }
     
     strcat(escSeq, "m");
-    printf("%s", escSeq);
+    if(printToStdOut) printf("%s", escSeq);
+    return escSeq;
+#else
+    return "";
 #endif
 }
 
-void CBashColor::setSpecial(ESpecial special)
+std::string CBashColor::setSpecial(ESpecial special, bool printToStdOut)
 {
 #ifndef DEBUG
     char num[3];
@@ -69,14 +72,21 @@ void CBashColor::setSpecial(ESpecial special)
     strcat(escSeq, num);
 
     strcat(escSeq, "m");
-    printf("%s", escSeq);
+    if(printToStdOut) printf("%s", escSeq);
+    return escSeq;
+#else
+    return "";
 #endif
 }
 
-void CBashColor::clearScreen()
+std::string CBashColor::clearScreen(bool printToStdOut)
 { 
 #ifndef DEBUG
-    printf("\033[H\033[J");
+    std::string escSeq = "\033[H\033[J";
+    if(printToStdOut) printf("%s", escSeq.c_str());
+    return escSeq;
+#else
+    return "";
 #endif
 }
 
@@ -137,4 +147,3 @@ void CBashControl::moveCursorTo(int x, int y)
     printf("\033[%i;%iH", y, x);
 #endif
 }
-

--- a/Utilities/BashColor.h
+++ b/Utilities/BashColor.h
@@ -19,6 +19,7 @@
 //
 
 #pragma once
+#include <string>
 
 class CBashControl
 {
@@ -43,10 +44,10 @@ public:
     enum ESpecial { specReset = 0, specBright, specDim, specUnderscore, specBlink, specReverese, SpecHidden };
     
 public:
-    CBashColor() {}
+    CBashColor() = default;
     
 public:
-    static void setColor(EColor foreground = colNone, EColor background = colNone);
-    static void setSpecial(ESpecial special = specReset);
-    static void clearScreen();
+    static std::string setColor(EColor foreground = colNone, EColor background = colNone, bool printToStdOut = true);
+    static std::string setSpecial(ESpecial special = specReset, bool printToStdOut = true);
+    static std::string clearScreen(bool printToStdOut = true);
 };


### PR DESCRIPTION
Both the REST API and the MolTwister Python package will be able to
* Retrieve the MolTwister startup text
* Retrieve the MolTwister help
* Retrieve the MolTwister help as a markdown document
* Retrieve the tutorials as markdown documents
